### PR TITLE
streamline dependency/module graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,11 @@ repositories {
 }
 
 dependencies {
+    api "eu.hansolo:toolboxfx:17.0.45"
     implementation "org.openjfx:javafx-base:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-graphics:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-controls:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-swing:${javafxVersion}:${platform}"
-    implementation "eu.hansolo:toolbox:17.0.55"
-    implementation "eu.hansolo:toolboxfx:17.0.45"
 }
 
 application {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,16 +3,15 @@ module eu.hansolo.fx.heatmap {
     requires java.base;
 
     // Java-FX
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-    requires transitive javafx.controls;
-    requires transitive javafx.swing;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires javafx.controls;
+    requires javafx.swing;
 
     // 3rd Party
-    requires transitive eu.hansolo.toolbox;
     requires transitive eu.hansolo.toolboxfx;
 
-    opens eu.hansolo.fx.heatmap to eu.hansolo.toolbox, eu.hansolo.toolboxfx;
+    opens eu.hansolo.fx.heatmap to eu.hansolo.toolboxfx;
 
     exports eu.hansolo.fx.heatmap;
 }


### PR DESCRIPTION
PR 2/4

This will help streamline the dependency graph across dependencies by using api configuration per gradle [docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_dependencies).

This allows the end user to only have to type `implementation 'eu.hansolo.fx:heatmap:17.0.25'` to get all the needed dependencies.

![dg-heatmap](https://github.com/HanSolo/heatmap/assets/3933065/c4724e87-d961-4ba5-82e8-e1ab5b10c59d)

Note: CI will fail until a release of `toolboxfx` is made after https://github.com/HanSolo/toolboxfx/pull/3

