### PR TITLE
Cleanup Deprecations and add Launcher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 }
 
 application {
-    mainClass = "eu.hansolo.fx.heatmap.Demo"
+    mainClass = "eu.hansolo.fx.heatmap.Launcher"
     mainModule = moduleName
 }
 
@@ -89,7 +89,7 @@ jar {
 
 // start the demo from gradle
 task Demo(type: JavaExec) {
-    mainClass = "eu.hansolo.fx.heatmap.Demo"
+    mainClass = "eu.hansolo.fx.heatmap.Launcher"
     classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 description   = 'A simple JavaFX heatmap implementation'
-mainClassName = "$moduleName/eu.hansolo.fx.heatmap.Demo" // Deprecated: Old Gradle 6.4 Syntax
 
 Date buildTimeAndDate = new Date()
 ext {

--- a/src/main/java/eu/hansolo/fx/heatmap/Launcher.java
+++ b/src/main/java/eu/hansolo/fx/heatmap/Launcher.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2016-2023 Gerrit Grunwald.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.hansolo.fx.heatmap;
+
+
+public class Launcher {
+    public static void main(String[] args) { Demo.main(args); }
+}


### PR DESCRIPTION
A launcher class did not exist so it caused the typical "Application" runtime issue when running via jar mode.

Removed the deprecated `mainClassName` entry since latest published jars are confirmed to be working without using it.